### PR TITLE
Issue 13 fr

### DIFF
--- a/R/mod_05_usage.R
+++ b/R/mod_05_usage.R
@@ -571,6 +571,43 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       )
   })
   
+  
+  full_usage_dat <- reactive({
+    req(usage_shiny(), usage_static())
+    
+    out <- usage_shiny() %>% 
+      dplyr::mutate(content_type = "Shiny App") %>% 
+      dplyr::select(content_type, title, owner_username, username, first_name, last_name, started, ended) %>% 
+      dplyr::bind_rows(
+        usage_static() %>% 
+          dplyr::mutate(content_type = "Static Content") %>% 
+          dplyr::select(content_type, title, owner_username, username, first_name, last_name, started = time) 
+      ) %>% 
+      dplyr::arrange(desc(started))
+    
+    return(out)
+  })
+  
+  output$full_usage_table <- reactable::renderReactable({
+    req(full_usage_dat())
+    
+   
+    
+    reactable::reactable(
+      full_usage_dat(), 
+      columns = list(
+        content_type = colDef("Content Type"),
+        title = colDef("Content Title"),
+        owner_username = colDef("Content Owner"),
+        username = colDef("Viewer Username"),
+        first_name = colDef("Viewer First Name"),
+        last_name = colDef("Viewer Last Name"),
+        started = colDef("Time Started", cell = function(value){format(value, "%b %d, %Y")}),
+        ended = colDef("Time Ended", cell = function(value){format(value, "%b %d, %Y")})
+      )
+    )
+  })
+  
   outputOptions(output, "app_user_count_cont", suspendWhenHidden = FALSE)
   outputOptions(output, "app_run_time", suspendWhenHidden = FALSE)
   outputOptions(output, "time_vis_fig", suspendWhenHidden = FALSE)

--- a/R/mod_05_usage.R
+++ b/R/mod_05_usage.R
@@ -181,6 +181,7 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       users <- r$all_users$guid[!r$all_users$locked]
       names(users) <- paste(r$all_users$first_name[!r$all_users$locked], r$all_users$last_name[!r$all_users$locked])
+      users <- c(users, "Anonymous" = "Anonymous")
       
       out <- tagList(
         fluidRow(
@@ -226,6 +227,7 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       users <- r$all_users$guid[!r$all_users$locked]
       names(users) <- paste(r$all_users$first_name[!r$all_users$locked], r$all_users$last_name[!r$all_users$locked])
+      users <- c(users, "Anonymous" = "Anonymous")
       
       out <- tagList(
         fluidRow(
@@ -286,6 +288,12 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       if (!is.null(input$filter_viewer)){
         if (input$filter_viewer != ""){
+          
+          if ("Anonymous" %in% input$filter_viewer){
+            shiny_usage <- dplyr::filter(shiny_usage, !is.na(user_guid))
+            static_usage <- dplyr::filter(static_usage, !is.na(user_guid))
+          }
+          
           shiny_usage <- dplyr::filter(shiny_usage, !user_guid %in% input$filter_viewer)
           static_usage <- dplyr::filter(static_usage, !user_guid %in% input$filter_viewer)
         }
@@ -304,6 +312,11 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       if (!is.null(input$filter_viewer)){
         if (input$filter_viewer != ""){
+          if ("Anonymous" %in% input$filter_viewer){
+            shiny_usage <- dplyr::filter(shiny_usage, !is.na(user_guid))
+            static_usage <- dplyr::filter(static_usage, !is.na(user_guid))
+          }
+          
           shiny_usage <- dplyr::filter(shiny_usage, !user_guid %in% input$filter_viewer)
           static_usage <- dplyr::filter(static_usage, !user_guid %in% input$filter_viewer)
         }
@@ -371,6 +384,9 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       if (!is.null(input$filter_viewer)){
         if (input$filter_viewer != ""){
+          if ("Anonymous" %in% input$filter_viewer){
+            out <- dplyr::filter(out, !is.na(user_guid))
+          }
           out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
         }
       }
@@ -383,6 +399,9 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       if (!is.null(input$filter_viewer)){
         if (input$filter_viewer != ""){
+          if ("Anonymous" %in% input$filter_viewer){
+            out <- dplyr::filter(out, !is.na(user_guid))
+          }
           out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
         }
       }
@@ -421,6 +440,9 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       if (!is.null(input$filter_viewer)){
         if (input$filter_viewer != ""){
+          if ("Anonymous" %in% input$filter_viewer){
+            out <- dplyr::filter(out, !is.na(user_guid))
+          }
           out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
         }
       }
@@ -433,6 +455,9 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       
       if (!is.null(input$filter_viewer)){
         if (input$filter_viewer != ""){
+          if ("Anonymous" %in% input$filter_viewer){
+            out <- dplyr::filter(out, !is.na(user_guid))
+          }
           out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
         }
       }

--- a/R/mod_05_usage.R
+++ b/R/mod_05_usage.R
@@ -39,7 +39,7 @@ mod_05_usage_ui <- function(id, admin = FALSE){
   out <- tagList(
     div(
       id = ns(div_id),
-      uiOutput(ns("admin_filters")),
+      uiOutput(ns("admin_filters"), inline = TRUE),
       fluidRow(
         shinydashboard::box(
           title = "Overall Content Usage",
@@ -163,25 +163,44 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
     content <- r$content$guid
     names(content) <- r$content$title
     
+    users <- r$all_users$guid[!r$all_users$locked]
+    names(users) <- paste(r$all_users$first_name[!r$all_users$locked], r$all_users$last_name[!r$all_users$locked])
+    
     out <- tagList(
-      div(
-        selectizeInput(
-          inputId = ns("filter_owner"),
-          label = "Exclude Content Owners",
-          choices = c("Select Content Owners to Exclude" = "", content_owners),
-          selected = "",
-          multiple = TRUE,
-          width = "47%"
+      fluidRow(
+        column(
+          width = 4,
+          selectizeInput(
+            inputId = ns("filter_owner"),
+            label = "Exclude Content Owners",
+            choices = c("Select Content Owners to Exclude" = "", content_owners),
+            selected = "",
+            multiple = TRUE,
+            width = "100%"
+          )
         ),
-        selectizeInput(
-          inputId = ns("filter_content"),
-          label = "Exclude Content",
-          choices = c("Select Content Owners to Exclude" = "", content),
-          selected = "",
-          multiple = TRUE,
-          width = "47%"
+        column(
+          width = 4,
+          selectizeInput(
+            inputId = ns("filter_content"),
+            label = "Exclude Content",
+            choices = c("Select Content Owners to Exclude" = "", content),
+            selected = "",
+            multiple = TRUE,
+            width = "100%"
+          )
         ),
-        style = "width:100%;margin: 0 auto;"
+        column(
+          width = 4,
+          selectizeInput(
+            inputId = ns("filter_viewer"),
+            label = "Exclude Viewers",
+            choices = c("Select Content Owners to Exclude" = "", users),
+            selected = "",
+            multiple = TRUE,
+            width = "100%"
+          )
+        )
       )
     )
     
@@ -198,14 +217,25 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       static_usage <- r$static_usage_all
       
       if (!is.null(input$filter_owner)){
-        owner_guids <- r$content$guid[r$content$owner_username == input$filter_owner]
-        shiny_usage <- dplyr::filter(shiny_usage, !content_guid %in% owner_guids)
-        static_usage <- dplyr::filter(static_usage, !content_guid %in% owner_guids)
+        if (input$filter_owner != ''){
+          owner_guids <- r$content$guid[r$content$owner_username == input$filter_owner]
+          shiny_usage <- dplyr::filter(shiny_usage, !content_guid %in% owner_guids)
+          static_usage <- dplyr::filter(static_usage, !content_guid %in% owner_guids)
+        }
       }
       
       if (!is.null(input$filter_content)){
-        shiny_usage <- dplyr::filter(shiny_usage, !content_guid %in% input$filter_content)
-        static_usage <- dplyr::filter(static_usage, !content_guid %in% input$filter_content)
+        if (input$filter_content != ""){
+          shiny_usage <- dplyr::filter(shiny_usage, !content_guid %in% input$filter_content)
+          static_usage <- dplyr::filter(static_usage, !content_guid %in% input$filter_content)
+        }
+      }
+      
+      if (!is.null(input$filter_viewer)){
+        if (input$filter_viewer != ""){
+          shiny_usage <- dplyr::filter(shiny_usage, !user_guid %in% input$filter_viewer)
+          static_usage <- dplyr::filter(static_usage, !user_guid %in% input$filter_viewer)
+        }
       }
     } else {
       req(r$shiny_usage, r$static_usage, r$username)
@@ -261,11 +291,21 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
     
     if (admin){
       if (!is.null(input$filter_owner)){
-        out <- dplyr::filter(out, !owner_username %in% input$filter_owner)
+        if (input$filter_owner != ''){
+          out <- dplyr::filter(out, !owner_username %in% input$filter_owner)
+        }
       }
       
       if (!is.null(input$filter_content)){
-        out <- dplyr::filter(out, !content_guid %in% input$filter_content)
+        if (input$filter_content != ""){
+          out <- dplyr::filter(out, !content_guid %in% input$filter_content)
+        }
+      }
+      
+      if (!is.null(input$filter_viewer)){
+        if (input$filter_viewer != ""){
+          out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
+        }
       }
     }
     
@@ -289,11 +329,21 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
     
     if (admin){
       if (!is.null(input$filter_owner)){
-        out <- dplyr::filter(out, !owner_username %in% input$filter_owner)
+        if (input$filter_owner != ''){
+          out <- dplyr::filter(out, !owner_username %in% input$filter_owner)
+        }
       }
       
       if (!is.null(input$filter_content)){
-        out <- dplyr::filter(out, !content_guid %in% input$filter_content)
+        if (input$filter_content != ""){
+          out <- dplyr::filter(out, !content_guid %in% input$filter_content)
+        }
+      }
+      
+      if (!is.null(input$filter_viewer)){
+        if (input$filter_viewer != ""){
+          out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
+        }
       }
     }
     

--- a/R/mod_05_usage.R
+++ b/R/mod_05_usage.R
@@ -94,6 +94,23 @@ mod_05_usage_ui <- function(id, admin = FALSE){
       ),
       fluidRow(
         shinydashboard::box(
+          title = "Content Usage Information",
+          reactable::reactableOutput(ns("full_usage_table")),
+          br(),
+          div(
+            downloadButton(
+              outputId = ns("download_usage_table"),
+              label = "Download Usage Info",
+              class = "btn-primary",
+              width = "100%"
+            ),
+            style = "width:250px;margin:0 auto;"
+          ),
+          width = 12
+        )
+      ),
+      fluidRow(
+        shinydashboard::box(
           title = "Content Timeline",
           timevis::timevisOutput(ns("time_vis_fig")),
           width = 12
@@ -596,21 +613,32 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
     reactable::reactable(
       full_usage_dat(), 
       columns = list(
-        content_type = colDef("Content Type"),
-        title = colDef("Content Title"),
-        owner_username = colDef("Content Owner"),
-        username = colDef("Viewer Username"),
-        first_name = colDef("Viewer First Name"),
-        last_name = colDef("Viewer Last Name"),
-        started = colDef("Time Started", cell = function(value){format(value, "%b %d, %Y")}),
-        ended = colDef("Time Ended", cell = function(value){format(value, "%b %d, %Y")})
-      )
+        content_type = reactable::colDef("Content Type"),
+        title = reactable::colDef("Content Title"),
+        owner_username = reactable::colDef("Content Owner"),
+        username = reactable::colDef("Viewer Username"),
+        first_name = reactable::colDef("Viewer First Name"),
+        last_name = reactable::colDef("Viewer Last Name"),
+        started = reactable::colDef("Time Started", cell = function(value){format(value, "%b %d, %Y")}),
+        ended = reactable::colDef("Time Ended", cell = function(value){format(value, "%b %d, %Y")})
+      ),
+      class = "usage-table"
     )
   })
+  
+  output$download_usage_table <- downloadHandler(
+    filename = function(){
+      paste0("connect-usage-", Sys.Date(), ".csv")
+    },
+    content = function(file){
+      write.csv(full_usage_dat(), file, row.names = FALSE)
+    }
+  )
   
   outputOptions(output, "app_user_count_cont", suspendWhenHidden = FALSE)
   outputOptions(output, "app_run_time", suspendWhenHidden = FALSE)
   outputOptions(output, "time_vis_fig", suspendWhenHidden = FALSE)
+  outputOptions(output, "full_usage_table", suspendWhenHidden = FALSE)
   
   
 }

--- a/R/mod_05_usage.R
+++ b/R/mod_05_usage.R
@@ -154,55 +154,91 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
   
   
   output$admin_filters <- renderUI({
-    if (!admin) return(NULL)
-    
-    content_owners <- r$content$owner_username
-    names(content_owners) <- paste(r$content$owner_first_name, r$content$owner_last_name) 
-    content_owners <- unique(content_owners)
-    
-    content <- r$content$guid
-    names(content) <- r$content$title
-    
-    users <- r$all_users$guid[!r$all_users$locked]
-    names(users) <- paste(r$all_users$first_name[!r$all_users$locked], r$all_users$last_name[!r$all_users$locked])
-    
-    out <- tagList(
-      fluidRow(
-        column(
-          width = 4,
-          selectizeInput(
-            inputId = ns("filter_owner"),
-            label = "Exclude Content Owners",
-            choices = c("Select Content Owners to Exclude" = "", content_owners),
-            selected = "",
-            multiple = TRUE,
-            width = "100%"
-          )
-        ),
-        column(
-          width = 4,
-          selectizeInput(
-            inputId = ns("filter_content"),
-            label = "Exclude Content",
-            choices = c("Select Content Owners to Exclude" = "", content),
-            selected = "",
-            multiple = TRUE,
-            width = "100%"
-          )
-        ),
-        column(
-          width = 4,
-          selectizeInput(
-            inputId = ns("filter_viewer"),
-            label = "Exclude Viewers",
-            choices = c("Select Content Owners to Exclude" = "", users),
-            selected = "",
-            multiple = TRUE,
-            width = "100%"
+    if (admin) {
+      content_owners <- r$content$owner_username
+      names(content_owners) <- paste(r$content$owner_first_name, r$content$owner_last_name) 
+      content_owners <- unique(content_owners)
+      
+      content <- r$content$guid
+      names(content) <- r$content$title
+      
+      users <- r$all_users$guid[!r$all_users$locked]
+      names(users) <- paste(r$all_users$first_name[!r$all_users$locked], r$all_users$last_name[!r$all_users$locked])
+      
+      out <- tagList(
+        fluidRow(
+          column(
+            width = 4,
+            selectizeInput(
+              inputId = ns("filter_owner"),
+              label = "Exclude Content Owners",
+              choices = c("Select Content Owners to Exclude" = "", content_owners),
+              selected = "",
+              multiple = TRUE,
+              width = "100%"
+            )
+          ),
+          column(
+            width = 4,
+            selectizeInput(
+              inputId = ns("filter_content"),
+              label = "Exclude Content",
+              choices = c("Select Content Owners to Exclude" = "", content),
+              selected = "",
+              multiple = TRUE,
+              width = "100%"
+            )
+          ),
+          column(
+            width = 4,
+            selectizeInput(
+              inputId = ns("filter_viewer"),
+              label = "Exclude Viewers",
+              choices = c("Select Content Owners to Exclude" = "", users),
+              selected = "",
+              multiple = TRUE,
+              width = "100%"
+            )
           )
         )
       )
-    )
+    } else {
+      
+      content <- r$user_content$guid
+      names(content) <- r$user_content$title
+      
+      users <- r$all_users$guid[!r$all_users$locked]
+      names(users) <- paste(r$all_users$first_name[!r$all_users$locked], r$all_users$last_name[!r$all_users$locked])
+      
+      out <- tagList(
+        fluidRow(
+          column(
+            width = 6,
+            selectizeInput(
+              inputId = ns("filter_content"),
+              label = "Exclude Content",
+              choices = c("Select Content Owners to Exclude" = "", content),
+              selected = "",
+              multiple = TRUE,
+              width = "100%"
+            )
+          ),
+          column(
+            width = 6,
+            selectizeInput(
+              inputId = ns("filter_viewer"),
+              label = "Exclude Viewers",
+              choices = c("Select Content Owners to Exclude" = "", users),
+              selected = "",
+              multiple = TRUE,
+              width = "100%"
+            )
+          )
+        )
+      )
+    }
+    
+    
     
     return(out)
   })
@@ -241,6 +277,20 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
       req(r$shiny_usage, r$static_usage, r$username)
       shiny_usage <- r$shiny_usage
       static_usage <- r$static_usage
+      
+      if (!is.null(input$filter_content)){
+        if (input$filter_content != ""){
+          shiny_usage <- dplyr::filter(shiny_usage, !content_guid %in% input$filter_content)
+          static_usage <- dplyr::filter(static_usage, !content_guid %in% input$filter_content)
+        }
+      }
+      
+      if (!is.null(input$filter_viewer)){
+        if (input$filter_viewer != ""){
+          shiny_usage <- dplyr::filter(shiny_usage, !user_guid %in% input$filter_viewer)
+          static_usage <- dplyr::filter(static_usage, !user_guid %in% input$filter_viewer)
+        }
+      }
     }
     
     out <- overall_usage_tbl(shiny_usage, static_usage, from = r$from, to = r$to)
@@ -307,6 +357,18 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
           out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
         }
       }
+    } else {
+      if (!is.null(input$filter_content)){
+        if (input$filter_content != ""){
+          out <- dplyr::filter(out, !content_guid %in% input$filter_content)
+        }
+      }
+      
+      if (!is.null(input$filter_viewer)){
+        if (input$filter_viewer != ""){
+          out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
+        }
+      }
     }
     
     return(out)
@@ -334,6 +396,18 @@ mod_05_usage_server <- function(input, output, session, r, admin = FALSE){
         }
       }
       
+      if (!is.null(input$filter_content)){
+        if (input$filter_content != ""){
+          out <- dplyr::filter(out, !content_guid %in% input$filter_content)
+        }
+      }
+      
+      if (!is.null(input$filter_viewer)){
+        if (input$filter_viewer != ""){
+          out <- dplyr::filter(out, !user_guid %in% input$filter_viewer)
+        }
+      }
+    } else {
       if (!is.null(input$filter_content)){
         if (input$filter_content != ""){
           out <- dplyr::filter(out, !content_guid %in% input$filter_content)

--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -9,4 +9,4 @@ golem::detach_all_attached()
 golem::document_and_reload()
 
 # Run the application
-connectAnalytics::connectAnalytics(switch_user = TRUE, user = "tbradley", header_width = 500)
+connectAnalytics::connectAnalytics(switch_user = TRUE, user = "tbradley", header_width = 300)

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -55,6 +55,17 @@
   padding: 8px 12px !important;
 }
 
+.usage-table {
+  border: 1px solid hsl(213, 33%, 93%);
+  border-radius: 4px;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1);
+}
+
+.usage-table .rt-th,
+.usage-table .rt-td {
+  padding: 8px 12px !important;
+}
+
 .sidebar {
   color: #FFF;
   position: fixed;


### PR DESCRIPTION
The PR will close #7 

Adds the following features:
  1.  Usage Filters:
    - User Tab: FIlter to exclude usage info by content name and viewer name
    - Admin Tab: Filter to exclude usage info by content owner, content name, and viewer name

  2. Usage Table:
    - There is now a usage table in both the user and admin tabs listing out the usage info for each usage instance (similar data to that in timeviz graphic)
    - Download button available to download the usage stats to a csv file